### PR TITLE
Fixed the unit moving too far

### DIFF
--- a/testTileMapLayer.tscn
+++ b/testTileMapLayer.tscn
@@ -37,6 +37,7 @@ z_index = 1
 
 [node name="Unit" parent="GameBoard" instance=ExtResource("4_dtmex")]
 position = Vector2(80, 48)
+scale = Vector2(1, 1)
 MoveRange = 8
 
 [node name="Cursor" parent="GameBoard" instance=ExtResource("6_hwsw5")]

--- a/unit.tscn
+++ b/unit.tscn
@@ -75,6 +75,7 @@ loop = false
 [node name="Sprite" type="Sprite2D" parent="PathFollow2D"]
 z_index = 1
 texture_filter = 1
+scale = Vector2(2, 2)
 texture = ExtResource("3_7rtpx")
 hframes = 4
 vframes = 5


### PR DESCRIPTION
It was because the Unit was doubled in scale, so its movement was too
I set the Unit's scaling back to 1, and doubled the scale of the _Sprite_ instead, so it still looks the same