### PR TITLE
Added deselect functionality when clicking on selected unit

### DIFF
--- a/GameBoard.cs
+++ b/GameBoard.cs
@@ -176,6 +176,13 @@ public partial class GameBoard : Node2D
 		{
 			SelectUnit(cell);
 		}
+		// If you click on the cell again, go through the deselect process the same as if "ui_cancel" is pressed
+		// GetValueOrDefault is there to prevent key errors when cell does not have a unit on it
+		// (and therefore does not have a corresponding value in the _units dictionary)
+		else if (_units.GetValueOrDefault(cell) == _activeUnit) {
+			DeselectActiveUnit();
+			ClearActiveUnit();
+		}
 		else if (_activeUnit.IsSelected)
 		{
 			MoveActiveUnit(cell);


### PR DESCRIPTION
When you click on a unit that you've already selected, it now deselects that unit. Upon examining the code I found that this functionality was actually already programmed in, for when the "ui_cancel" input is detected (experimentally, this is bound to the esc key on keyboards), so it was relatively simple to apply the same function to clicking the same unit again. If we want to adjust behavior upon clicking on a selected unit (like, say, opening a context menu like Fire Emblem does) we now have a place to put that functionality.